### PR TITLE
store event listener in vdom

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "Yoorkin/rabbit-tea",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "readme": "README.md",
   "repository": "https://github.com/Yoorkin/rabbit-tea",
   "license": "Apache-2.0",

--- a/src/internal/ffi/dom_element.mbt
+++ b/src/internal/ffi/dom_element.mbt
@@ -47,14 +47,14 @@ pub extern "js" fn remove_attribute(self : Element, attr : String) -> Unit = "(s
 pub extern "js" fn add_event_listener(
   self : Element,
   event : String,
-  callback : (Event) -> Unit
+  listener : Listener
 ) -> Unit = "(self,event,callback) => self.addEventListener(event, callback)"
 
 ///|
 pub extern "js" fn remove_event_listener(
   self : Element,
   event : String,
-  callback : (Event) -> Unit
+  listener : Listener
 ) -> Unit = "(self,event,callback) => self.removeEventListener(event, callback)"
 
 ///|

--- a/src/internal/ffi/event.mbt
+++ b/src/internal/ffi/event.mbt
@@ -19,3 +19,6 @@ pub extern "js" fn prevent_default(self : Event) =
 ///|
 pub extern "js" fn stop_propagation(self : Event) =
   #| (self) => self.stopPropagation()
+
+///|
+pub typealias Listener = (Event) -> Unit

--- a/src/internal/ffi/ffi.mbti
+++ b/src/internal/ffi/ffi.mbti
@@ -104,6 +104,7 @@ impl Text {
 }
 
 // Type aliases
+pub typealias Listener = (Event) -> Unit
 
 // Traits
 

--- a/src/internal/vdom/dom.mbt
+++ b/src/internal/vdom/dom.mbt
@@ -20,7 +20,13 @@
 
 ///|
 enum Node[Msg] {
-  Node(String, attrs~ : Array[Attribute[Msg]], childrens~ : Array[Node[Msg]])
+  Node(
+    String,
+    attrs~ : Array[Attribute[Msg]],
+    childrens~ : Array[Node[Msg]],
+    // Store the event listener uesd in real DOM
+    listeners~ : Array[(String, @ffi.Listener)]
+  )
   Text(String)
   Fragment(Array[Node[Msg]])
   Nothing
@@ -34,7 +40,7 @@ pub fn map[A, B](self : Node[A], f : (A) -> B) -> Node[B] {
     Node(tag, attrs~, childrens~) => {
       let attrs = attrs.map(fn(x) { x.map(f) })
       let childrens = childrens.map(fn(x) { x.map(f) })
-      Node(tag, attrs~, childrens~)
+      Node(tag, attrs~, childrens~, listeners=[])
     }
     Text(value) => Text(value)
     Fragment(childrens) => Fragment(childrens.map(fn(x) { x.map(f) }))
@@ -48,7 +54,7 @@ pub fn node[Msg](
   attrs : Array[Attribute[Msg]],
   childrens : Array[Node[Msg]]
 ) -> Node[Msg] {
-  Node(tag, attrs~, childrens~)
+  Node(tag, attrs~, childrens~, listeners=[])
 }
 
 ///| Create a plain text
@@ -89,7 +95,6 @@ enum AttrValue[Msg] {
 pub(all) enum Handler[Msg] {
   Normal(Msg)
   HandleEvent((@ffi.Event) -> Msg)
-  TriggerUrlChange(String)
   Custom(Msg, stop_progapation~ : Bool, prevent_default~ : Bool)
 }
 
@@ -163,11 +168,11 @@ fn to_node[Msg, Model, View](
   // 
   // This function require a sandbox value, and use closure to eliminate the type parameter.
   match self {
-    Node(tag, attrs~, childrens~) => {
+    Node(tag, attrs~, childrens~) as node => {
       let element = @ffi.document().create_element(tag)
       attrs.each(fn {
         Attribute((event, AttrEvent(handler))) => {
-          let cb = match handler {
+          let listener = match handler {
             Normal(msg) => fn(_event) { sandbox.update(msg) }
             HandleEvent(f) => fn(event) { sandbox.update(f(event)) }
             Custom(msg, stop_progapation~, prevent_default~) =>
@@ -181,7 +186,8 @@ fn to_node[Msg, Model, View](
                 sandbox.update(msg)
               }
           }
-          element.add_event_listener(event, cb)
+          element.add_event_listener(event, listener)
+          node.listeners.push((event, listener))
         }
         Attribute((key, AttrString(value))) => element.set_attribute(key, value)
         Attribute((key, AttrStyle(value))) => element.set_style(key, value)

--- a/src/internal/vdom/vdom.mbti
+++ b/src/internal/vdom/vdom.mbti
@@ -31,7 +31,6 @@ impl Attribute {
 pub(all) enum Handler {
   Normal(Msg)
   HandleEvent((@ffi.Event) -> Msg)
-  TriggerUrlChange(String)
   Custom(Msg, Bool, Bool)
 }
 impl Handler {

--- a/src/url/url.mbt
+++ b/src/url/url.mbt
@@ -60,7 +60,7 @@ pub fn parse(url : String) -> Url!Error {
     _ => fail!("Invalid host")
   }
   let (mid, path) = match mid.split("/").collect() {
-    [mid, .. as paths] =>
+    [mid, .. paths] =>
       (mid, String::concat(paths.iter().collect(), separator="/"))
     [mid] => (mid, "")
     _ => fail!("Invalid host")


### PR DESCRIPTION
Store the event listeners previously registered in `to_node` in the virtual DOM.

Note: If you convert a virtual DOM to a real DOM using the `to_node` function twice (this should not happen), the generated listeners will both be stored in the same array. cc @Lampese 